### PR TITLE
Clarify login flow UX

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -4,3 +4,5 @@ alwaysApply: true
 Always run Python code with `uv run`.
 
 Write statically typed Python and run lint and type checks with `uv run ruff check --fix` and `uv run ty check`.
+
+Practice test-driven development. Always write tests first, verify they fail for the right reasons (RED), then write the code to make them pass (GREEN), then refactor to clean up the code.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ uv tool install -U git+https://github.com/Promptly-Technologies-LLC/birdapp.git
 After installation, you can use:
 
 ```bash
-birdapp config
+birdapp auth config
 birdapp tweet --text "Hello world!"
 ```
 
@@ -51,7 +51,7 @@ In the dashboard, you will need to create an application. Make sure your applica
 Run the configuration command to set up your credentials:
 
 ```bash
-birdapp config
+birdapp auth config --oauth1 # or --oauth2
 ```
 
 This will prompt you for your Twitter API credentials and store them securely in `~/.config/birdapp/config.json`.
@@ -59,8 +59,25 @@ This will prompt you for your Twitter API credentials and store them securely in
 To view your current configuration (without showing secrets):
 
 ```bash
-birdapp config --show
+birdapp auth config --show
 ```
+
+### Auth Flows
+
+Birdapp supports both OAuth1 and OAuth2. Choose based on your security posture and how
+your X app is registered.
+
+OAuth1:
+- No separate login step once configured.
+- Stores app key/secret and user access token/secret locally.
+- Configuration is single-account (one set of tokens at a time).
+
+OAuth2 (Authorization Code with PKCE):
+- Requires a separate login step.
+- Tokens are stored per user id (multiple accounts supported).
+- `auth whoami` defaults to the first stored token unless `--user-id` is provided.
+- If `X_OAUTH2_CLIENT_SECRET` is set, the client behaves as confidential; otherwise it
+  uses public PKCE and avoids storing an app secret. The user experience is the same for both flows, but you may need to use the confidential flow if you registered your app as confidential.
 
 ### OAuth2 (User Context)
 
@@ -74,19 +91,19 @@ OAuth2 uses Authorization Code with PKCE. Configure these environment variables:
 You can set these via the config workflow:
 
 ```bash
-birdapp config --oauth2
+birdapp auth config --oauth2
 ```
 
 To authenticate and store a token:
 
 ```bash
-birdapp oauth2 login
+birdapp auth login
 ```
 
 To verify the token:
 
 ```bash
-birdapp oauth2 whoami
+birdapp auth whoami
 ```
 
 For development fixture capture:
@@ -184,7 +201,7 @@ To see help for a specific command:
 
 ```bash
 birdapp tweet --help
-birdapp config --help
+birdapp auth --help
 birdapp get --help
 birdapp user --help
 ```

--- a/birdapp/auth.py
+++ b/birdapp/auth.py
@@ -16,7 +16,7 @@ def create_oauth1_auth() -> OAuth1:
     if missing_vars:
         raise ValueError(
             f"Missing required credentials: {', '.join(missing_vars)}. "
-            "Run 'uv run main.py config' to set up your Twitter API credentials."
+            "Run `birdapp auth config --oauth1` to set up your credentials."
         )
     
     return OAuth1(

--- a/birdapp/config.py
+++ b/birdapp/config.py
@@ -77,7 +77,7 @@ def show_config() -> None:
     """Show current configuration (without secrets)."""
     config = load_config()
     if not config:
-        print("No configuration found. Run 'birdapp config' to set up credentials.")
+        print("No configuration found. Run `birdapp auth config` to set up credentials.")
         return
     
     print("Current configuration:")

--- a/birdapp/oauth2.py
+++ b/birdapp/oauth2.py
@@ -214,16 +214,16 @@ def oauth2_whoami(user_id: str | None = None) -> dict[str, Any]:
         sessions_dir = get_sessions_dir()
         tokens_path = os.path.join(sessions_dir, "tokens.json")
         if not os.path.exists(tokens_path):
-            raise RuntimeError("No OAuth2 tokens stored. Run `birdapp oauth2 login` first.")
+            raise RuntimeError("No OAuth2 tokens stored. Run `birdapp auth login` first.")
 
         with open(tokens_path, "r") as f:
             tokens = f.read().strip()
         if not tokens:
-            raise RuntimeError("No OAuth2 tokens stored. Run `birdapp oauth2 login` first.")
+            raise RuntimeError("No OAuth2 tokens stored. Run `birdapp auth login` first.")
 
         tokens_data = json.loads(tokens)
         if not tokens_data:
-            raise RuntimeError("No OAuth2 tokens stored. Run `birdapp oauth2 login` first.")
+            raise RuntimeError("No OAuth2 tokens stored. Run `birdapp auth login` first.")
 
         first_user_id = next(iter(tokens_data.keys()))
         token = tokens_data[first_user_id]

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -1,0 +1,106 @@
+import sys
+import unittest
+from unittest import mock
+
+from birdapp import main as main_module
+
+
+class TestAuthCli(unittest.TestCase):
+    def test_auth_config_oauth2_flag_calls_prompt(self) -> None:
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "auth", "config", "--oauth2"]),
+            mock.patch("birdapp.main.prompt_for_oauth2_credentials") as oauth2_prompt,
+            mock.patch("birdapp.main.prompt_for_credentials") as oauth1_prompt,
+        ):
+            main_module.main()
+
+        oauth2_prompt.assert_called_once()
+        oauth1_prompt.assert_not_called()
+
+    def test_auth_config_show_calls_show_config(self) -> None:
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "auth", "config", "--show"]),
+            mock.patch("birdapp.main.show_config") as show_config,
+        ):
+            main_module.main()
+
+        show_config.assert_called_once()
+
+    def test_auth_config_prompts_for_flow(self) -> None:
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "auth", "config"]),
+            mock.patch("builtins.input", return_value="oauth2"),
+            mock.patch("birdapp.main.prompt_for_oauth2_credentials") as oauth2_prompt,
+        ):
+            main_module.main()
+
+        oauth2_prompt.assert_called_once()
+
+    def test_auth_login_requires_oauth2_config(self) -> None:
+        def fake_get_credential(key: str) -> str | None:
+            return None
+
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "auth", "login"]),
+            mock.patch("birdapp.main.get_credential", side_effect=fake_get_credential),
+            mock.patch("birdapp.main.os.getenv", return_value=None),
+            mock.patch("birdapp.main.oauth2_login_flow") as oauth2_login_flow,
+            mock.patch("builtins.print") as print_mock,
+        ):
+            main_module.main()
+
+        oauth2_login_flow.assert_not_called()
+        printed = " ".join(" ".join(map(str, args)) for args, _ in print_mock.call_args_list)
+        self.assertIn("OAuth2 credentials are not configured", printed)
+
+    def test_auth_login_skips_when_oauth1_configured(self) -> None:
+        def fake_get_credential(key: str) -> str | None:
+            oauth1_values = {
+                "X_API_KEY": "key",
+                "X_API_SECRET": "secret",
+                "X_ACCESS_TOKEN": "token",
+                "X_ACCESS_TOKEN_SECRET": "token-secret",
+            }
+            return oauth1_values.get(key)
+
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "auth", "login"]),
+            mock.patch("birdapp.main.get_credential", side_effect=fake_get_credential),
+            mock.patch("birdapp.main.os.getenv", return_value=None),
+            mock.patch("birdapp.main.oauth2_login_flow") as oauth2_login_flow,
+            mock.patch("builtins.print") as print_mock,
+        ):
+            main_module.main()
+
+        oauth2_login_flow.assert_not_called()
+        printed = " ".join(" ".join(map(str, args)) for args, _ in print_mock.call_args_list)
+        self.assertIn("OAuth1 credentials are configured", printed)
+
+    def test_auth_login_runs_oauth2_flow(self) -> None:
+        def fake_get_credential(key: str) -> str | None:
+            oauth2_values = {
+                "X_OAUTH2_CLIENT_ID": "client",
+                "X_OAUTH2_REDIRECT_URI": "http://127.0.0.1:8080/callback",
+            }
+            return oauth2_values.get(key)
+
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "auth", "login"]),
+            mock.patch("birdapp.main.get_credential", side_effect=fake_get_credential),
+            mock.patch("birdapp.main.os.getenv", return_value=None),
+            mock.patch("birdapp.main.oauth2_login_flow", return_value={"data": {"id": "1"}})
+            as oauth2_login_flow,
+        ):
+            main_module.main()
+
+        oauth2_login_flow.assert_called_once()
+
+    def test_auth_whoami_calls_oauth2_whoami(self) -> None:
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "auth", "whoami"]),
+            mock.patch("birdapp.main.oauth2_whoami", return_value={"data": {"id": "1"}})
+            as oauth2_whoami,
+        ):
+            main_module.main()
+
+        oauth2_whoami.assert_called_once()


### PR DESCRIPTION
## Plan: Auth Command Rework

### Context
The CLI currently exposes OAuth2-only commands under `birdapp oauth2 ...` and OAuth1
credentials are configured via `birdapp config`, with a `--oauth2` flag for OAuth2.
We will replace `oauth2` with a new `auth` namespace, move `config` under `auth`,
and remove obsolete commands without backward compatibility.

### Goals
- Provide a single `auth` namespace for all auth-related actions.
- Make `auth config` interactive by default, with flags for scripting.
- Remove the top-level `config` command and the `oauth2` command entirely.
- Preserve OAuth1 and OAuth2 behavior, with clearer UX for login requirements.
- Update README to document auth flows and differences accurately.

### Non-goals
- Backward compatibility or deprecation messaging.
- Changes to OAuth protocols or token storage.

### User-facing CLI Shape
- `birdapp auth config` (interactive prompt: OAuth1 vs OAuth2)
- `birdapp auth config --oauth1`
- `birdapp auth config --oauth2`
- `birdapp auth login`
- `birdapp auth whoami`
- `birdapp auth --show` (or `birdapp auth config --show`; choose one and document)

### Behavior Requirements
- `auth config`:
  - Prompt for OAuth1 or OAuth2 when no flag is provided.
  - `--oauth1` runs the current OAuth1 credential prompt.
  - `--oauth2` runs the current OAuth2 credential prompt.
  - `--show` prints current config (no secrets).
- `auth login`:
  - If OAuth2 config is missing, instruct user to run `birdapp auth config`.
  - If OAuth1 is configured but OAuth2 is not, explain OAuth1 has no login step.
  - Otherwise run OAuth2 login flow.
- `auth whoami`:
  - Same behavior as current OAuth2 whoami.

### README Updates
- Replace old commands:
  - `birdapp config` -> `birdapp auth config`
  - `birdapp config --oauth2` -> `birdapp auth config --oauth2`
  - `birdapp oauth2 login` -> `birdapp auth login`
  - `birdapp oauth2 whoami` -> `birdapp auth whoami`
- Add a short section comparing OAuth1 vs OAuth2 (public PKCE vs confidential),
  emphasizing:
  - OAuth1 stores app key/secret and user token/secret; no separate login; single
    account via config.
  - OAuth2 public (PKCE): login step, no app secret stored; tokens stored per user.
  - OAuth2 confidential: same flow plus optional client secret; same token storage.
  - CLI defaults to first stored OAuth2 token unless user id is provided.

### TDD Implementation Steps
1. Add CLI tests that assert:
   - `auth config` prompts and calls correct config flow.
   - `auth login` errors when OAuth2 config missing.
   - `auth login` warns when only OAuth1 is configured.
   - `auth whoami` is wired to OAuth2 whoami.
2. Run tests and confirm expected failures (RED).
3. Implement `auth` command structure and prompt logic (GREEN).
4. Refactor any shared config/auth helper logic and verify `oauth2` and `config` commands are removed (REFACTOR).
5. Update README and verify commands match behavior.
6. Run `uv run ruff check --fix` and `uv run ty check`.

### Open Decisions
- `--show` placement: prefer `birdapp auth config --show` unless it includes login status.
- `auth whoami` should default to the first stored token.
