### PR TITLE
Allow tweeting with a positional text argument

### DIFF
--- a/birdapp/main.py
+++ b/birdapp/main.py
@@ -124,7 +124,19 @@ def main() -> None:
 
     # Tweet subcommand
     tweet_parser = subparsers.add_parser('tweet', help='Post a tweet')
-    tweet_parser.add_argument('--text', type=str, help='Tweet text to post (optional if media provided)', default="")
+    tweet_parser.add_argument(
+        "text",
+        nargs="?",
+        default=None,
+        help="Tweet text to post (optional if media provided)",
+    )
+    tweet_parser.add_argument(
+        "--text",
+        dest="text_flag",
+        type=str,
+        default=None,
+        help="Tweet text to post (optional if media provided)",
+    )
     tweet_parser.add_argument('--media', type=str, help='Path to media file (optional)')
     tweet_parser.add_argument('--reply-to', dest='reply_to', type=str, help='Tweet ID or URL to reply to (optional)')
     
@@ -323,15 +335,21 @@ def main() -> None:
     
     # Handle tweet command
     if args.command == 'tweet':
+        if args.text_flag is not None and args.text is not None:
+            print("Error: Provide tweet text either positionally or with --text, not both")
+            raise SystemExit(1)
+
+        text = (args.text_flag or args.text or "").strip()
+
         # Validate arguments
-        if not args.text.strip() and not args.media:
+        if not text and not args.media:
             print("Error: Cannot post empty tweet without media")
             exit(1)
         
         # Post the tweet
         try:
             success, message = post_tweet(
-                text=args.text,
+                text=text,
                 media_path=args.media,
                 reply_to=args.reply_to
             )

--- a/tests/test_tweet_cli.py
+++ b/tests/test_tweet_cli.py
@@ -1,0 +1,28 @@
+import sys
+import unittest
+from unittest import mock
+
+from birdapp import main as main_module
+
+
+class TestTweetCli(unittest.TestCase):
+    def test_tweet_cli_accepts_positional_text(self) -> None:
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "tweet", "hello world"]),
+            mock.patch("birdapp.main.post_tweet", return_value=(True, "ok")) as post_tweet,
+            mock.patch("builtins.print"),
+        ):
+            main_module.main()
+
+        post_tweet.assert_called_once_with(text="hello world", media_path=None, reply_to=None)
+
+    def test_tweet_cli_still_accepts_text_flag(self) -> None:
+        with (
+            mock.patch.object(sys, "argv", ["birdapp", "tweet", "--text", "hello world"]),
+            mock.patch("birdapp.main.post_tweet", return_value=(True, "ok")) as post_tweet,
+            mock.patch("builtins.print"),
+        ):
+            main_module.main()
+
+        post_tweet.assert_called_once_with(text="hello world", media_path=None, reply_to=None)
+


### PR DESCRIPTION
The tweet command no longer requires the --text flag to tweet text; you can now pass text as a positional argument without the flag.