### PR TITLE
Increase accuracy of 'auth config --show' output

### DIFF
--- a/birdapp/config.py
+++ b/birdapp/config.py
@@ -145,6 +145,8 @@ def get_credential(key: str, profile: str | None = None) -> Optional[str]:
             if key in _OAUTH2_APP_KEYS:
                 return oauth2_app.get(key)
             return None
+        if key == "X_OAUTH2_SCOPES":
+            return oauth2_app.get(key)
         profile_value = profiles.get(profile_name, {}).get(key)
         if profile_value:
             return profile_value
@@ -272,17 +274,17 @@ def show_config(profile: str | None = None) -> None:
     print(f"  API Secret: {'*' * len(profile_data.get('X_API_SECRET', '')) if profile_data.get('X_API_SECRET') else 'Not set'}")
     print(f"  Access Token: {'*' * len(profile_data.get('X_ACCESS_TOKEN', '')) if profile_data.get('X_ACCESS_TOKEN') else 'Not set'}")
     print(f"  Access Token Secret: {'*' * len(profile_data.get('X_ACCESS_TOKEN_SECRET', '')) if profile_data.get('X_ACCESS_TOKEN_SECRET') else 'Not set'}")
-    print("  OAuth2 Client ID: " + ("Set" if profile_data.get("X_OAUTH2_CLIENT_ID") else "Not set"))
-    print("  OAuth2 Client Secret: " + ("Set" if profile_data.get("X_OAUTH2_CLIENT_SECRET") else "Not set"))
-    print("  OAuth2 Redirect URI: " + (profile_data.get("X_OAUTH2_REDIRECT_URI") or "Not set"))
-    print("  OAuth2 Scopes: " + (profile_data.get("X_OAUTH2_SCOPES") or "Not set"))
     oauth2_app = _get_oauth2_app_config(config)
     if oauth2_app:
+        from .oauth2 import DEFAULT_OAUTH2_SCOPES
+
+        raw_scopes = oauth2_app.get("X_OAUTH2_SCOPES")
+        scopes_display = raw_scopes or f"Default ({DEFAULT_OAUTH2_SCOPES})"
         print("OAuth2 App Configuration (shared):")
         print("  OAuth2 Client ID: " + ("Set" if oauth2_app.get("X_OAUTH2_CLIENT_ID") else "Not set"))
         print("  OAuth2 Client Secret: " + ("Set" if oauth2_app.get("X_OAUTH2_CLIENT_SECRET") else "Not set"))
         print("  OAuth2 Redirect URI: " + (oauth2_app.get("X_OAUTH2_REDIRECT_URI") or "Not set"))
-        print("  OAuth2 Scopes: " + (oauth2_app.get("X_OAUTH2_SCOPES") or "Not set"))
+        print("  OAuth2 Scopes: " + scopes_display)
 
 def prompt_for_oauth2_credentials(profile: str | None = None) -> None:
     """Prompt user for OAuth2 credentials and save them."""

--- a/tests/test_config_show_oauth2_scopes.py
+++ b/tests/test_config_show_oauth2_scopes.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest import mock
+
+from birdapp.oauth2 import DEFAULT_OAUTH2_SCOPES
+
+
+class TestConfigShowOAuth2Scopes(unittest.TestCase):
+    def test_show_config_prints_default_oauth2_scopes_when_not_explicitly_set(self) -> None:
+        config = {
+            "active_profile": "WSPZoo",
+            "profiles": {"WSPZoo": {"X_USERNAME": "WSPZoo"}},
+            "oauth2_app": {
+                "X_OAUTH2_CLIENT_ID": "client-id",
+                "X_OAUTH2_CLIENT_SECRET": "client-secret",
+                "X_OAUTH2_REDIRECT_URI": "http://127.0.0.1:5000/oauth/callback",
+                # X_OAUTH2_SCOPES intentionally omitted -> defaults should be used.
+            },
+        }
+
+        with (
+            mock.patch("birdapp.config.load_config", return_value=config),
+            mock.patch("builtins.print") as print_mock,
+        ):
+            from birdapp import config as config_module
+
+            config_module.show_config()
+
+        printed = "\n".join(" ".join(map(str, args)) for args, _ in print_mock.call_args_list)
+        self.assertIn(f"OAuth2 Scopes: Default ({DEFAULT_OAUTH2_SCOPES})", printed)
+        self.assertNotIn("OAuth2 Scopes: Not set", printed)
+        self.assertEqual(printed.count("OAuth2 Scopes:"), 1)
+
+    def test_show_config_prints_explicit_oauth2_scopes_when_set(self) -> None:
+        config = {
+            "active_profile": "WSPZoo",
+            "profiles": {"WSPZoo": {"X_USERNAME": "WSPZoo"}},
+            "oauth2_app": {
+                "X_OAUTH2_CLIENT_ID": "client-id",
+                "X_OAUTH2_CLIENT_SECRET": "client-secret",
+                "X_OAUTH2_REDIRECT_URI": "http://127.0.0.1:5000/oauth/callback",
+                "X_OAUTH2_SCOPES": "tweet.read users.read",
+            },
+        }
+
+        with (
+            mock.patch("birdapp.config.load_config", return_value=config),
+            mock.patch("builtins.print") as print_mock,
+        ):
+            from birdapp import config as config_module
+
+            config_module.show_config()
+
+        printed = "\n".join(" ".join(map(str, args)) for args, _ in print_mock.call_args_list)
+        self.assertIn("OAuth2 Scopes: tweet.read users.read", printed)
+        self.assertNotIn(f"OAuth2 Scopes: Default ({DEFAULT_OAUTH2_SCOPES})", printed)
+        self.assertEqual(printed.count("OAuth2 Scopes:"), 1)
+

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "birdapp"
-version = "1.4.0"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
`birdapp auth config --show` was displaying inaccurate output. This PR makes the output more correct and more useful.

- Since OAuth2 scopes are set globally, OAuth2 secrets no longer appear as redundant entries in the profile-level config list.
- Oauth2 secrets correctly display as "Set" when properly configured.
- Default scopes are interpreted as "Set" instead of "Not set".
- Scopes are treated as non-sensitive and shown to the user.
